### PR TITLE
Feat: 봉사 매칭 연결

### DIFF
--- a/backend/ongi_backend/build.gradle
+++ b/backend/ongi_backend/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/backend/ongi_backend/build.gradle
+++ b/backend/ongi_backend/build.gradle
@@ -36,6 +36,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/config/RedisConfig.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/config/RedisConfig.java
@@ -1,12 +1,19 @@
 package com.example.ongi_backend.global.config;
 
+import static org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents.*;
+import static org.springframework.data.redis.core.RedisKeyValueAdapter.ShadowCopy.OFF;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@EnableRedisRepositories(shadowCopy = OFF, enableKeyspaceEvents = ON_DEMAND)
 public class RedisConfig {
 	@Value("${spring.data.redis.host}")
 	private String host;
@@ -16,5 +23,14 @@ public class RedisConfig {
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
 		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate(){
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		return redisTemplate;
 	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/config/RedisConfig.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.example.ongi_backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+	@Value("${spring.data.redis.host}")
+	private String host;
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/Address.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/Address.java
@@ -9,12 +9,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @Builder
 @Embeddable
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
+@ToString
 public class Address {
 	@Enumerated(STRING)
 	private DistrictType district;

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/VolunteerStatus.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/VolunteerStatus.java
@@ -1,5 +1,13 @@
 package com.example.ongi_backend.global.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum VolunteerStatus {
-	COMPLETED, PROGRESS, REVIEWING
+	COMPLETED("완료된 봉사"), PROGRESS("진행 중인 봉사"), REVIEWING("후기 작성해야 되는 봉사"), MATCHING("매칭중인 봉사"),;
+	private final String description;
+
+	VolunteerStatus(String description) {
+		this.description = description;
+	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/VolunteerType.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/VolunteerType.java
@@ -1,6 +1,20 @@
 package com.example.ongi_backend.global.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum VolunteerType {
 	//TODO: 종류가 뭐 있는지 몰라서 나중에 추가하는걸로
-	health,
+	HEALTH(1),
+	HOUSING(2),
+	CULTURE(4),
+	EDUCATION(8),
+	;
+	private final Integer category;
+	VolunteerType(int category) {
+		this.category = category;
+	}
+	public static Integer getCategory(VolunteerType volunteerType) {
+		return volunteerType.category;
+	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/exception/ErrorCode.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 	// REQUEST_PARAMETER_TYPE_NOT_MATCH_ERROR(400, "GLOBAL-005", "입력 파라미터의 타입이 올바르지 않습니다."),
 	//volunteerActivity
 	NOT_FOUND_VOLUNTEER_ACTIVITY_ERROR(404, "VOLUNTEER-001", "봉사활동을 찾을 수 없습니다."),
+	UNAVAILABLE_CANCLE_VOLUNTEER_ACTIVITY_ERROR(400, "VOLUNTEER-002", "봉사활동 취소가 불가능합니다."),
 	//item
 	// CHAT_ROOM_JOIN_ERROR(400,"CHATROOM-001", "?"),
 	ITEM_NOT_FOUND_ERROR(404,"ITEM-001", "해당 상품이 존재하지 않습니다"),

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/exception/ErrorCode.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 	// INTERNAL_SERVER_ERROR(500, "GLOBAL-001", "서버에 오류가 발생하였습니다."),
 	INPUT_INVALID_VALUE_ERROR(400, "GLOBAL-002", "잘못된 입력 값입니다."),
 	EMPTY_INPUT_ERROR(400, "GLOBAL-003", "입력 값이 비어있습니다."),
+	POST_TIME_ERROR(400, "GLOBAL-004", "시간이 지났습니다."),
 	// INPUT_INVALID_TYPE_ERROR(400, "GLOBAL-003", "잘못된 입력 타입입니다."),
 	// REQUEST_PARAMETER_NOT_FOUND_ERROR(400, "GLOBAL-004", "입력 파라미터가 존재하지 않습니다."),
 	// REQUEST_PARAMETER_TYPE_NOT_MATCH_ERROR(400, "GLOBAL-005", "입력 파라미터의 타입이 올바르지 않습니다."),

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/dto/UnMatching.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/dto/UnMatching.java
@@ -1,0 +1,41 @@
+package com.example.ongi_backend.global.redis.dto;
+
+import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import com.example.ongi_backend.global.entity.Address;
+import com.example.ongi_backend.global.entity.AnimalType;
+import com.example.ongi_backend.global.entity.VolunteerType;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@RedisHash("UnMatching")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+@ToString
+@Getter
+public class UnMatching {
+	@Id
+	@GeneratedValue(strategy = UUID)
+	private String id;
+	private Long elderlyId;
+	private VolunteerType volunteerType;
+	private String addDescription;
+	private LocalDateTime startTime;
+	private AnimalType animalType;
+	private Address address;
+	@TimeToLive
+	private Long ttl;
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/dto/UnMatching.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/dto/UnMatching.java
@@ -12,7 +12,6 @@ import com.example.ongi_backend.global.entity.Address;
 import com.example.ongi_backend.global.entity.AnimalType;
 import com.example.ongi_backend.global.entity.VolunteerType;
 
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,8 +27,7 @@ import lombok.ToString;
 @Getter
 public class UnMatching {
 	@Id
-	@GeneratedValue(strategy = UUID)
-	private String id;
+	private Long id;
 	private Long elderlyId;
 	private VolunteerType volunteerType;
 	private String addDescription;

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/repository/UnMatchingRepository.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/repository/UnMatchingRepository.java
@@ -1,0 +1,14 @@
+package com.example.ongi_backend.global.redis.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.ongi_backend.global.redis.dto.UnMatching;
+
+@Repository
+public interface UnMatchingRepository extends CrudRepository<UnMatching, String> {
+	@Override
+	List<UnMatching> findAll();
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/repository/UnMatchingRepository.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/repository/UnMatchingRepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 import com.example.ongi_backend.global.redis.dto.UnMatching;
 
 @Repository
-public interface UnMatchingRepository extends CrudRepository<UnMatching, String> {
+public interface UnMatchingRepository extends CrudRepository<UnMatching, Long> {
 	@Override
 	List<UnMatching> findAll();
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/service/UnMatchingService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/service/UnMatchingService.java
@@ -1,0 +1,52 @@
+package com.example.ongi_backend.global.redis.service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.ongi_backend.global.entity.Address;
+import com.example.ongi_backend.global.entity.AnimalType;
+import com.example.ongi_backend.global.entity.VolunteerType;
+import com.example.ongi_backend.global.redis.dto.UnMatching;
+import com.example.ongi_backend.global.redis.repository.UnMatchingRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UnMatchingService {
+	private final UnMatchingRepository unMatchingRepository;
+	@Transactional
+	public void saveUnMatching(Long vId, Long eId, VolunteerType volunteerType, LocalDateTime startTime, AnimalType animalType, Address address, String addDescription) {
+		unMatchingRepository.save(UnMatching.builder()
+			.id(vId)
+			.elderlyId(eId)
+			.volunteerType(volunteerType)
+			.startTime(startTime)
+			.animalType(animalType)
+			.address(address)
+			.addDescription(addDescription)
+			.ttl(
+				Duration.between(LocalDateTime.now(), startTime).getSeconds()
+			)
+			.build());
+	}
+
+	@Transactional
+	public void deleteUnMatching(UnMatching unMatching) {
+		unMatchingRepository.delete(unMatching);
+	}
+
+	@Transactional
+	public void deleteUnMatchingById(Long id) {
+		unMatchingRepository.deleteById(id);
+	}
+
+	public List<UnMatching> findAllUnMatching() {
+		return unMatchingRepository.findAll();
+	}
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/ElderlyController.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/ElderlyController.java
@@ -1,0 +1,30 @@
+package com.example.ongi_backend.user.Controller;
+
+import java.security.Principal;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.ongi_backend.user.Service.ElderlyService;
+import com.example.ongi_backend.volunteerActivity.dto.RequestMatching;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/elderly")
+public class ElderlyController {
+	private final ElderlyService elderlyService;
+
+	@PostMapping("/matching")
+	public void activityMatching(@RequestBody RequestMatching request, Principal principal) {
+		elderlyService.matching(request,
+			//TODO : 로그인 구현 후 수정
+			// principal.getName()
+			"username"
+		);
+	}
+
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/ElderlyController.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/ElderlyController.java
@@ -2,6 +2,8 @@ package com.example.ongi_backend.user.Controller;
 
 import java.security.Principal;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +23,15 @@ public class ElderlyController {
 	@PostMapping("/matching")
 	public void activityMatching(@RequestBody RequestMatching request, Principal principal) {
 		elderlyService.matching(request,
+			//TODO : 로그인 구현 후 수정
+			// principal.getName()
+			"username"
+		);
+	}
+
+	@DeleteMapping("/matching/{matchingId}")
+	public void cancelMatching(@PathVariable Long matchingId ,Principal principal) {
+		elderlyService.cancelMatching(matchingId,
 			//TODO : 로그인 구현 후 수정
 			// principal.getName()
 			"username"

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/VolunteerController.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/VolunteerController.java
@@ -1,0 +1,32 @@
+package com.example.ongi_backend.user.Controller;
+
+import java.security.Principal;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.ongi_backend.user.Dto.ScheduleRequest;
+import com.example.ongi_backend.user.Service.VolunteerService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/volunteer")
+public class VolunteerController {
+	private final VolunteerService volunteerService;
+
+	@PostMapping("/schedule")
+	public ResponseEntity<?> setSchedule(@RequestBody ScheduleRequest request, Principal principal) {
+		volunteerService.updateSchedule(request.getSchedules(),
+			"username"
+			// TODO : 로그인 구현 후 주석 해제
+			// principal.getName()
+		);
+		return null;
+	}
+
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/VolunteerController.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/VolunteerController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.ongi_backend.user.Dto.ScheduleRequest;
 import com.example.ongi_backend.user.Service.VolunteerService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -22,8 +23,8 @@ public class VolunteerController {
 	private final VolunteerService volunteerService;
 
 	@PostMapping("/schedule")
-	public ResponseEntity<?> setSchedule(@RequestBody ScheduleRequest request, Principal principal) {
-		volunteerService.updateSchedule(request.getSchedules(),
+	public ResponseEntity<?> setSchedule(@Valid @RequestBody ScheduleRequest request, Principal principal) {
+		volunteerService.updateSchedule(request.getSchedules(),request.getCategory(),
 			"username"
 			// TODO : 로그인 구현 후 주석 해제
 			// principal.getName()

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/VolunteerController.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/VolunteerController.java
@@ -3,6 +3,8 @@ package com.example.ongi_backend.user.Controller;
 import java.security.Principal;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +27,15 @@ public class VolunteerController {
 			"username"
 			// TODO : 로그인 구현 후 주석 해제
 			// principal.getName()
+		);
+		return null;
+	}
+	@DeleteMapping("/matching/{matchingId}")
+	public ResponseEntity<?> deleteMatching(@PathVariable Long matchingId, Principal principal) {
+		volunteerService.deleteMatching(matchingId,
+			"username"
+			// TODO : 로그인 구현 후 주석 해제
+			// principal.getName()ㅌ
 		);
 		return null;
 	}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Dto/ScheduleRequest.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Dto/ScheduleRequest.java
@@ -4,11 +4,15 @@ import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.List;
 
+import org.hibernate.validator.constraints.Range;
+
 import lombok.Data;
 
 @Data
 public class ScheduleRequest {
 	private List<Schedules> schedules;
+	@Range(min = 1, max = 15)
+	private int category;
 	@Data
 	public static class Schedules {
 		private DayOfWeek dayOfWeek;

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Dto/ScheduleRequest.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Dto/ScheduleRequest.java
@@ -1,0 +1,17 @@
+package com.example.ongi_backend.user.Dto;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class ScheduleRequest {
+	private List<Schedules> schedules;
+	@Data
+	public static class Schedules {
+		private DayOfWeek dayOfWeek;
+		private LocalTime time;
+	}
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Repository/VolunteerRepository.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Repository/VolunteerRepository.java
@@ -1,5 +1,6 @@
 package com.example.ongi_backend.user.Repository;
 
+import com.example.ongi_backend.global.entity.DistrictType;
 import com.example.ongi_backend.user.entity.Volunteer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -20,9 +21,10 @@ public interface VolunteerRepository extends JpaRepository<Volunteer, Long> {
         + "where w.dayOfWeek = :dayOfWeek "
         + "and w.availableStartTime = :availableStartTime "
         + "and bitand(v.volunteerCategory, :category) = :category "
+        + "and v.address.district = :district "
         + "and not exists (select 1 from VolunteerActivity va where va.volunteer = v and date_format(va.startTime, '%Y-%m-%d') = :date)"
         + "order by function('RAND') limit 1")
-    Optional<Volunteer> findByWeeklyAvailableTime(DayOfWeek dayOfWeek, LocalTime availableStartTime, LocalDate date, int category);
+    Optional<Volunteer> findByWeeklyAvailableTime(DayOfWeek dayOfWeek, LocalTime availableStartTime, LocalDate date, int category, DistrictType district);
 
 
 

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Repository/VolunteerRepository.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Repository/VolunteerRepository.java
@@ -2,12 +2,28 @@ package com.example.ongi_backend.user.Repository;
 
 import com.example.ongi_backend.user.entity.Volunteer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Optional;
 
 @Repository
 public interface VolunteerRepository extends JpaRepository<Volunteer, Long> {
     boolean existsByUsername(String username);
     Optional<Volunteer> findByUsername(String username);
+
+    @Query("select v from Volunteer v "
+        + "join v.weeklyAvailableTimes w on w.volunteer = v "
+        + "where w.dayOfWeek = :dayOfWeek "
+        + "and w.availableStartTime = :availableStartTime "
+        + "and bitand(v.volunteerCategory, :category) = :category "
+        + "and not exists (select 1 from VolunteerActivity va where va.volunteer = v and date_format(va.startTime, '%Y-%m-%d') = :date)"
+        + "order by function('RAND') limit 1")
+    Optional<Volunteer> findByWeeklyAvailableTime(DayOfWeek dayOfWeek, LocalTime availableStartTime, LocalDate date, int category);
+
+
+
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
@@ -1,0 +1,45 @@
+package com.example.ongi_backend.user.Service;
+
+import static com.example.ongi_backend.global.exception.ErrorCode.*;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+
+import com.example.ongi_backend.global.exception.CustomException;
+import com.example.ongi_backend.global.redis.dto.UnMatching;
+import com.example.ongi_backend.global.redis.repository.UnMatchingRepository;
+import com.example.ongi_backend.user.Repository.ElderlyRepository;
+import com.example.ongi_backend.user.entity.Elderly;
+import com.example.ongi_backend.volunteerActivity.dto.RequestMatching;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ElderlyService {
+	private final ElderlyRepository elderlyRepository;
+	private final VolunteerService volunteerService;
+	private final UnMatchingRepository unMatchingRepository;
+
+	public void matching(RequestMatching request, String name) {
+		// TODO : 봉사자 weeklyAvailable 검색 과정 추가. 지금은 검색 안됬다고 가정
+		Elderly elderly = elderlyRepository.findByUsername(name)
+			.orElseThrow(() -> new CustomException(NOT_FOUND_USER_ERROR));
+		unMatchingRepository.save(UnMatching.builder()
+			.elderlyId(elderly.getId())
+			.volunteerType(request.getVolunteerType())
+			.startTime(request.getStartTime())
+			.animalType(request.getAnimalType())
+			.address(request.getAddress())
+			.addDescription(request.getAddDescription())
+			.ttl(
+				Duration.between(LocalDateTime.now(), request.getStartTime()).getSeconds()
+			)
+			.build());
+		// TODO : 매칭 안됨 알림?
+
+
+	}
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
@@ -19,7 +19,6 @@ import com.example.ongi_backend.global.redis.repository.UnMatchingRepository;
 import com.example.ongi_backend.user.Repository.ElderlyRepository;
 import com.example.ongi_backend.user.Repository.VolunteerRepository;
 import com.example.ongi_backend.user.entity.Elderly;
-import com.example.ongi_backend.user.entity.Volunteer;
 import com.example.ongi_backend.volunteerActivity.dto.RequestMatching;
 import com.example.ongi_backend.volunteerActivity.entity.VolunteerActivity;
 import com.example.ongi_backend.volunteerActivity.service.VolunteerActivityService;
@@ -76,5 +75,26 @@ public class ElderlyService {
 					)
 					.build());
 			});
+	}
+
+	@Transactional
+	public void cancelMatching(Long id, String username) {
+		// TODO : 중복되는 기능은 따로 메소드로 분리
+		VolunteerActivity findVolunteerActivity = volunteerActivityService.findById(id);
+		Elderly elderly = elderlyRepository.findByUsername(username).orElseThrow(
+			() -> new CustomException(NOT_FOUND_USER_ERROR)
+		);
+		if(findVolunteerActivity.getElderly() != elderly) {
+			throw new CustomException(ACCESS_DENIED_ERROR);
+		}
+		if(findVolunteerActivity.getStatus().equals(PROGRESS)) {
+			volunteerActivityService.deleteActivity(id);
+		} else if (findVolunteerActivity.getStatus().equals(MATCHING)) {
+			// TODO : 봉사자에게 취소 알림 전송
+			volunteerActivityService.deleteActivity(id);
+			unMatchingRepository.deleteById(id);
+		}else{
+			throw new CustomException(UNAVAILABLE_CANCLE_VOLUNTEER_ACTIVITY_ERROR);
+		}
 	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
@@ -84,7 +84,7 @@ public class ElderlyService {
 		Elderly elderly = elderlyRepository.findByUsername(username).orElseThrow(
 			() -> new CustomException(NOT_FOUND_USER_ERROR)
 		);
-		if(findVolunteerActivity.getElderly() != elderly) {
+		if(!findVolunteerActivity.getElderly().equals(elderly)) {
 			throw new CustomException(ACCESS_DENIED_ERROR);
 		}
 		if(findVolunteerActivity.getStatus().equals(PROGRESS)) {

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
@@ -1,45 +1,81 @@
 package com.example.ongi_backend.user.Service;
 
+import static com.example.ongi_backend.global.entity.VolunteerStatus.*;
 import static com.example.ongi_backend.global.exception.ErrorCode.*;
 
+import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.example.ongi_backend.global.entity.VolunteerType;
 import com.example.ongi_backend.global.exception.CustomException;
 import com.example.ongi_backend.global.redis.dto.UnMatching;
 import com.example.ongi_backend.global.redis.repository.UnMatchingRepository;
 import com.example.ongi_backend.user.Repository.ElderlyRepository;
+import com.example.ongi_backend.user.Repository.VolunteerRepository;
 import com.example.ongi_backend.user.entity.Elderly;
+import com.example.ongi_backend.user.entity.Volunteer;
 import com.example.ongi_backend.volunteerActivity.dto.RequestMatching;
+import com.example.ongi_backend.volunteerActivity.entity.VolunteerActivity;
+import com.example.ongi_backend.volunteerActivity.service.VolunteerActivityService;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ElderlyService {
 	private final ElderlyRepository elderlyRepository;
-	private final VolunteerService volunteerService;
+	private final VolunteerRepository volunteerRepository;
+	private final VolunteerActivityService volunteerActivityService;
 	private final UnMatchingRepository unMatchingRepository;
 
+	@Transactional(rollbackFor = Exception.class)
 	public void matching(RequestMatching request, String name) {
-		// TODO : 봉사자 weeklyAvailable 검색 과정 추가. 지금은 검색 안됬다고 가정
+
+		if(Duration.between(LocalDateTime.now(), request.getStartTime()).getSeconds() < 0L) {
+			throw new CustomException(POST_TIME_ERROR);
+		}
+
+		//TODO : 현재 로그인된 노인의 정보를 가져오는 방법이 따로 있으면 수정
 		Elderly elderly = elderlyRepository.findByUsername(name)
 			.orElseThrow(() -> new CustomException(NOT_FOUND_USER_ERROR));
-		unMatchingRepository.save(UnMatching.builder()
-			.elderlyId(elderly.getId())
-			.volunteerType(request.getVolunteerType())
-			.startTime(request.getStartTime())
-			.animalType(request.getAnimalType())
-			.address(request.getAddress())
-			.addDescription(request.getAddDescription())
-			.ttl(
-				Duration.between(LocalDateTime.now(), request.getStartTime()).getSeconds()
-			)
-			.build());
-		// TODO : 매칭 안됨 알림?
 
+		VolunteerActivity volunteerActivity = volunteerActivityService.addVolunteerActivity(request, elderly);
 
+		// 매칭 가능한 봉사자 찾기
+		DayOfWeek dayOfWeek = request.getStartTime().getDayOfWeek();
+		LocalTime startTime = request.getStartTime().toLocalTime();
+		LocalDate date = request.getStartTime().toLocalDate();
+		Integer category = VolunteerType.getCategory(request.getVolunteerType());
+
+		Volunteer volunteer = volunteerRepository.findByWeeklyAvailableTime(dayOfWeek, startTime, date, category)
+			.orElseGet(() -> {
+				// TODO : 매칭 안됨 알림 기능 추가
+				unMatchingRepository.save(UnMatching.builder()
+						.id(volunteerActivity.getId())
+					.elderlyId(elderly.getId())
+					.volunteerType(request.getVolunteerType())
+					.startTime(request.getStartTime())
+					.animalType(request.getAnimalType())
+					.address(request.getAddress())
+					.addDescription(request.getAddDescription())
+					.ttl(
+						Duration.between(LocalDateTime.now(), request.getStartTime()).getSeconds()
+					)
+					.build());
+				// TODO : return null 말고 다른 방법이 있는지?
+				return null;
+			});
+		if(volunteer != null) {
+			// TODO : 매칭 완료 알림 기능 추가
+			volunteerActivity.updateStatus(PROGRESS);
+			volunteerActivity.updateVolunteer(volunteer);
+		}
 	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
@@ -3,21 +3,15 @@ package com.example.ongi_backend.user.Service;
 import static com.example.ongi_backend.global.entity.VolunteerStatus.*;
 import static com.example.ongi_backend.global.exception.ErrorCode.*;
 
-import java.time.DayOfWeek;
 import java.time.Duration;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.example.ongi_backend.global.entity.VolunteerType;
 import com.example.ongi_backend.global.exception.CustomException;
-import com.example.ongi_backend.global.redis.dto.UnMatching;
-import com.example.ongi_backend.global.redis.repository.UnMatchingRepository;
+import com.example.ongi_backend.global.redis.service.UnMatchingService;
 import com.example.ongi_backend.user.Repository.ElderlyRepository;
-import com.example.ongi_backend.user.Repository.VolunteerRepository;
 import com.example.ongi_backend.user.entity.Elderly;
 import com.example.ongi_backend.volunteerActivity.dto.RequestMatching;
 import com.example.ongi_backend.volunteerActivity.entity.VolunteerActivity;
@@ -30,9 +24,9 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class ElderlyService {
 	private final ElderlyRepository elderlyRepository;
-	private final VolunteerRepository volunteerRepository;
 	private final VolunteerActivityService volunteerActivityService;
-	private final UnMatchingRepository unMatchingRepository;
+	private final UnMatchingService unMatchingService;
+	private final VolunteerService volunteerService;
 
 	@Transactional
 	public void matching(RequestMatching request, String name) {
@@ -45,42 +39,13 @@ public class ElderlyService {
 		Elderly elderly = elderlyRepository.findByUsername(name)
 			.orElseThrow(() -> new CustomException(NOT_FOUND_USER_ERROR));
 
-		VolunteerActivity volunteerActivity = volunteerActivityService.addVolunteerActivity(request, elderly);
-
-		// 매칭 가능한 봉사자 찾기
-		DayOfWeek dayOfWeek = request.getStartTime().getDayOfWeek();
-		LocalTime startTime = request.getStartTime().toLocalTime();
-		LocalDate date = request.getStartTime().toLocalDate();
-		Integer category = VolunteerType.getCategory(request.getVolunteerType());
-
-		volunteerRepository.findByWeeklyAvailableTime(dayOfWeek, startTime, date, category, request.getAddress()
-			.getDistrict()).ifPresentOrElse(
-			volunteer -> {
-				// TODO : 매칭 알림 추가
-				volunteerActivity.updateStatus(PROGRESS);
-				volunteerActivity.updateVolunteer(volunteer);
-			},
-			() -> {
-				// TODO : 매칭 안됨 알림 기능 추가
-				unMatchingRepository.save(UnMatching.builder()
-					.id(volunteerActivity.getId())
-					.elderlyId(elderly.getId())
-					.volunteerType(request.getVolunteerType())
-					.startTime(request.getStartTime())
-					.animalType(request.getAnimalType())
-					.address(request.getAddress())
-					.addDescription(request.getAddDescription())
-					.ttl(
-						Duration.between(LocalDateTime.now(), request.getStartTime()).getSeconds()
-					)
-					.build());
-			});
+		volunteerService.matchingIfDayOfWeekTimeMatched(request, elderly);
 	}
 
 	@Transactional
 	public void cancelMatching(Long id, String username) {
-		// TODO : 중복되는 기능은 따로 메소드로 분리
 		VolunteerActivity findVolunteerActivity = volunteerActivityService.findById(id);
+		// TODO : 현재 로그인된 노인의 정보를 가져오는 방법이 따로 있으면 수정
 		Elderly elderly = elderlyRepository.findByUsername(username).orElseThrow(
 			() -> new CustomException(NOT_FOUND_USER_ERROR)
 		);
@@ -92,7 +57,7 @@ public class ElderlyService {
 		} else if (findVolunteerActivity.getStatus().equals(MATCHING)) {
 			// TODO : 봉사자에게 취소 알림 전송
 			volunteerActivityService.deleteActivity(id);
-			unMatchingRepository.deleteById(id);
+			unMatchingService.deleteUnMatchingById(id);
 		}else{
 			throw new CustomException(UNAVAILABLE_CANCLE_VOLUNTEER_ACTIVITY_ERROR);
 		}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
@@ -1,0 +1,39 @@
+package com.example.ongi_backend.user.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.ongi_backend.global.exception.CustomException;
+import com.example.ongi_backend.global.exception.ErrorCode;
+import com.example.ongi_backend.user.Dto.ScheduleRequest;
+import com.example.ongi_backend.user.Repository.VolunteerRepository;
+import com.example.ongi_backend.user.entity.Volunteer;
+import com.example.ongi_backend.weeklyAvailableTime.entity.WeeklyAvailableTime;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VolunteerService {
+	private final VolunteerRepository volunteerRepository;
+
+	@Transactional
+	public void updateSchedule(List<ScheduleRequest.Schedules> schedules, String username) {
+		Volunteer volunteer = volunteerRepository.findByUsername(username).orElseThrow(
+			() -> new CustomException(ErrorCode.NOT_FOUND_USER_ERROR)
+		);
+		List<WeeklyAvailableTime> collect = schedules.stream().map(schedule -> {
+			return WeeklyAvailableTime.builder()
+				.dayOfWeek(schedule.getDayOfWeek())
+				.availableStartTime(schedule.getTime())
+				.availableEndTime(schedule.getTime().plusHours(3))
+				.volunteer(volunteer)
+				.build();
+		}).collect(Collectors.toList());
+		volunteer.addWeeklyAvailableTime(collect);
+	}
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
@@ -1,16 +1,22 @@
 package com.example.ongi_backend.user.Service;
 
+import static com.example.ongi_backend.global.entity.VolunteerStatus.*;
+import static com.example.ongi_backend.global.exception.ErrorCode.*;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.ongi_backend.global.entity.VolunteerType;
 import com.example.ongi_backend.global.exception.CustomException;
-import com.example.ongi_backend.global.exception.ErrorCode;
+import com.example.ongi_backend.global.redis.repository.UnMatchingRepository;
 import com.example.ongi_backend.user.Dto.ScheduleRequest;
 import com.example.ongi_backend.user.Repository.VolunteerRepository;
 import com.example.ongi_backend.user.entity.Volunteer;
+import com.example.ongi_backend.volunteerActivity.entity.VolunteerActivity;
+import com.example.ongi_backend.volunteerActivity.repository.VolunteerActivityRepository;
 import com.example.ongi_backend.weeklyAvailableTime.entity.WeeklyAvailableTime;
 
 import lombok.RequiredArgsConstructor;
@@ -20,11 +26,13 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class VolunteerService {
 	private final VolunteerRepository volunteerRepository;
+	private final UnMatchingRepository unMatchingRepository;
+	private final VolunteerActivityRepository volunteerActivityRepository;
 
 	@Transactional
 	public void updateSchedule(List<ScheduleRequest.Schedules> schedules, String username) {
 		Volunteer volunteer = volunteerRepository.findByUsername(username).orElseThrow(
-			() -> new CustomException(ErrorCode.NOT_FOUND_USER_ERROR)
+			() -> new CustomException(NOT_FOUND_USER_ERROR)
 		);
 		List<WeeklyAvailableTime> collect = schedules.stream().map(schedule -> {
 			return WeeklyAvailableTime.builder()
@@ -35,5 +43,34 @@ public class VolunteerService {
 				.build();
 		}).collect(Collectors.toList());
 		volunteer.addWeeklyAvailableTime(collect);
+		scanUnMatching(collect, volunteer);
+	}
+
+	@Transactional
+	public void scanUnMatching(List<WeeklyAvailableTime> weeklyAvailableTimes, Volunteer volunteer) {
+		unMatchingRepository.findAll().forEach(unMatching -> {
+			weeklyAvailableTimes.forEach(weeklyAvailableTime -> {
+				if(unMatching.getStartTime().getDayOfWeek().equals(weeklyAvailableTime.getDayOfWeek())
+					&& unMatching.getStartTime().toLocalTime().equals(weeklyAvailableTime.getAvailableStartTime())
+					&& (VolunteerType.getCategory(unMatching.getVolunteerType()) & weeklyAvailableTime.getVolunteer().getVolunteerCategory()) != 0
+					&& unMatching.getAddress().getDistrict().equals(weeklyAvailableTime.getVolunteer().getAddress().getDistrict())) {
+					volunteerActivityRepository.findByStartTimeAndVolunteer(unMatching.getStartTime(), volunteer).ifPresentOrElse(
+						activity -> {
+							// 이미 해당 날짜에 매칭된 경우
+						},
+						() -> {
+							// TODO : 매칭 알림 전송
+							unMatchingRepository.delete(unMatching);
+							VolunteerActivity volunteerActivity = volunteerActivityRepository.findById(
+								unMatching.getId()).orElseThrow(
+								() -> new CustomException(NOT_FOUND_VOLUNTEER_ACTIVITY_ERROR)
+							);
+							volunteerActivity.updateStatus(PROGRESS);
+							volunteerActivity.updateVolunteer(volunteer);
+						}
+					);
+				}
+			});
+		});
 	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
@@ -35,7 +35,7 @@ public class VolunteerService {
 	private final UnMatchingService unMatchingService;
 
 	@Transactional
-	public void updateSchedule(List<ScheduleRequest.Schedules> schedules, String username) {
+	public void updateSchedule(List<ScheduleRequest.Schedules> schedules, int category, String username) {
 		Volunteer volunteer = volunteerRepository.findByUsername(username).orElseThrow(
 			() -> new CustomException(NOT_FOUND_USER_ERROR)
 		);
@@ -47,6 +47,7 @@ public class VolunteerService {
 				.volunteer(volunteer)
 				.build();
 		}).collect(Collectors.toList());
+		volunteer.updateCategory(category);
 		volunteer.addWeeklyAvailableTime(collect);
 		scanUnMatching(collect, volunteer);
 	}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
@@ -3,6 +3,8 @@ package com.example.ongi_backend.user.Service;
 import static com.example.ongi_backend.global.entity.VolunteerStatus.*;
 import static com.example.ongi_backend.global.exception.ErrorCode.*;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -11,12 +13,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.ongi_backend.global.entity.VolunteerType;
 import com.example.ongi_backend.global.exception.CustomException;
+import com.example.ongi_backend.global.redis.dto.UnMatching;
 import com.example.ongi_backend.global.redis.repository.UnMatchingRepository;
 import com.example.ongi_backend.user.Dto.ScheduleRequest;
 import com.example.ongi_backend.user.Repository.VolunteerRepository;
 import com.example.ongi_backend.user.entity.Volunteer;
 import com.example.ongi_backend.volunteerActivity.entity.VolunteerActivity;
 import com.example.ongi_backend.volunteerActivity.repository.VolunteerActivityRepository;
+import com.example.ongi_backend.volunteerActivity.service.VolunteerActivityService;
 import com.example.ongi_backend.weeklyAvailableTime.entity.WeeklyAvailableTime;
 
 import lombok.RequiredArgsConstructor;
@@ -26,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class VolunteerService {
 	private final VolunteerRepository volunteerRepository;
+	private final VolunteerActivityService volunteerActivityService;
 	private final UnMatchingRepository unMatchingRepository;
 	private final VolunteerActivityRepository volunteerActivityRepository;
 
@@ -72,5 +77,41 @@ public class VolunteerService {
 				}
 			});
 		});
+	}
+
+	@Transactional
+	public void deleteMatching(Long id, String username) {
+		// TODO : 중복되는 기능은 따로 메소드로 분리
+		VolunteerActivity findVolunteerActivity = volunteerActivityService.findById(id);
+		Volunteer volunteer = volunteerRepository.findByUsername(username).orElseThrow(
+			() -> new CustomException(NOT_FOUND_USER_ERROR)
+		);
+		if (findVolunteerActivity.getVolunteer() == null || !findVolunteerActivity.getVolunteer().equals(volunteer)) {
+			throw new CustomException(ACCESS_DENIED_ERROR);
+		}
+		if(findVolunteerActivity.getStatus().equals(PROGRESS)) {
+			// TODO : 노인에게 봉사 취소 알림 전송
+			findVolunteerActivity.updateVolunteer(null);
+			findVolunteerActivity.updateStatus(MATCHING);
+			// TODO : unMatchingService로 분리
+			unMatchingRepository.save(
+				UnMatching.builder()
+					.id(findVolunteerActivity.getId())
+					.elderlyId(findVolunteerActivity.getElderly().getId())
+					.volunteerType(findVolunteerActivity.getType())
+					.startTime(findVolunteerActivity.getStartTime())
+					.animalType(findVolunteerActivity.getAnimalType())
+					.address(findVolunteerActivity.getAddress())
+					.addDescription(findVolunteerActivity.getAddDescription())
+					.ttl(
+						Duration.between(LocalDateTime.now(), findVolunteerActivity.getStartTime()).getSeconds())
+					.build()
+			);
+		}else {
+			throw new CustomException(UNAVAILABLE_CANCLE_VOLUNTEER_ACTIVITY_ERROR);
+		}
+
+
+		return ;
 	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/entity/Volunteer.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/entity/Volunteer.java
@@ -20,6 +20,7 @@ public class Volunteer extends BaseUser {
 	private List<VolunteerActivity> volunteerActivities = new ArrayList<>();
 	@OneToMany(mappedBy = "volunteer", cascade = CascadeType.PERSIST, orphanRemoval = true)
 	private List<WeeklyAvailableTime> weeklyAvailableTimes = new ArrayList<>();
+	private Integer volunteerCategory;
 	public void addWeeklyAvailableTime(List<WeeklyAvailableTime> weeklyAvailableTime) {
 		weeklyAvailableTimes.clear();
 		weeklyAvailableTimes.addAll(weeklyAvailableTime);

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/entity/Volunteer.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/entity/Volunteer.java
@@ -25,6 +25,9 @@ public class Volunteer extends BaseUser {
 		weeklyAvailableTimes.clear();
 		weeklyAvailableTimes.addAll(weeklyAvailableTime);
 	}
+	public void updateCategory(Integer category) {
+		this.volunteerCategory = category;
+	}
 	protected Volunteer() {
 		super();
 	}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/entity/Volunteer.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/entity/Volunteer.java
@@ -3,10 +3,10 @@ package com.example.ongi_backend.user.entity;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.example.ongi_backend.global.entity.Address;
-import com.example.ongi_backend.global.entity.Gender;
 import com.example.ongi_backend.volunteerActivity.entity.VolunteerActivity;
+import com.example.ongi_backend.weeklyAvailableTime.entity.WeeklyAvailableTime;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import lombok.*;
@@ -18,7 +18,12 @@ import lombok.experimental.SuperBuilder;
 public class Volunteer extends BaseUser {
 	@OneToMany(mappedBy = "volunteer")
 	private List<VolunteerActivity> volunteerActivities = new ArrayList<>();
-
+	@OneToMany(mappedBy = "volunteer", cascade = CascadeType.PERSIST, orphanRemoval = true)
+	private List<WeeklyAvailableTime> weeklyAvailableTimes = new ArrayList<>();
+	public void addWeeklyAvailableTime(List<WeeklyAvailableTime> weeklyAvailableTime) {
+		weeklyAvailableTimes.clear();
+		weeklyAvailableTimes.addAll(weeklyAvailableTime);
+	}
 	protected Volunteer() {
 		super();
 	}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/volunteerActivity/dto/RequestMatching.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/volunteerActivity/dto/RequestMatching.java
@@ -1,0 +1,18 @@
+package com.example.ongi_backend.volunteerActivity.dto;
+
+import java.time.LocalDateTime;
+
+import com.example.ongi_backend.global.entity.Address;
+import com.example.ongi_backend.global.entity.AnimalType;
+import com.example.ongi_backend.global.entity.VolunteerType;
+
+import lombok.Data;
+
+@Data
+public class RequestMatching {
+	private VolunteerType volunteerType;
+	private String addDescription;
+	private LocalDateTime startTime;
+	private AnimalType animalType;
+	private Address address;
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/volunteerActivity/entity/VolunteerActivity.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/volunteerActivity/entity/VolunteerActivity.java
@@ -3,6 +3,7 @@ package com.example.ongi_backend.volunteerActivity.entity;
 import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.FetchType.*;
 import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
 
 import java.time.LocalDateTime;
 
@@ -21,10 +22,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
 public class VolunteerActivity extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
@@ -38,6 +45,7 @@ public class VolunteerActivity extends BaseEntity {
 	@Enumerated(STRING)
 	private VolunteerType type;
 	private String addDescription;
+	// TODO : 날짜로 index를 사용하면 성능이 좋아질 것 같음, 나중에 테스트 해보고 성능이 좋으면 변경
 	private LocalDateTime startTime;
 	@Enumerated(STRING)
 	private AnimalType animalType;
@@ -45,4 +53,12 @@ public class VolunteerActivity extends BaseEntity {
 	private VolunteerStatus status;
 	@Embedded
 	private Address address;
+
+	public void updateStatus(VolunteerStatus status) {
+		this.status = status;
+	}
+
+	public void updateVolunteer(Volunteer volunteer) {
+		this.volunteer = volunteer;
+	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/volunteerActivity/repository/VolunteerActivityRepository.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/volunteerActivity/repository/VolunteerActivityRepository.java
@@ -1,5 +1,6 @@
 package com.example.ongi_backend.volunteerActivity.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -7,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import com.example.ongi_backend.user.entity.Volunteer;
 import com.example.ongi_backend.volunteerActivity.entity.VolunteerActivity;
 
 @Repository
@@ -22,4 +24,5 @@ public interface VolunteerActivityRepository extends JpaRepository<VolunteerActi
 	@Query("SELECT va FROM VolunteerActivity va JOIN FETCH va.elderly JOIN FETCH va.volunteer WHERE va.volunteer.username = :username")
 	List<VolunteerActivity> findMatchingByUserName(String username);
 
+	Optional<VolunteerActivity> findByStartTimeAndVolunteer(LocalDateTime startTime, Volunteer volunteer);
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/volunteerActivity/service/VolunteerActivityService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/volunteerActivity/service/VolunteerActivityService.java
@@ -115,4 +115,13 @@ public class VolunteerActivityService {
 		VolunteerActivity save = volunteerActivityRepository.save(volunteerActivity);
 		return save;
 	}
+
+	public VolunteerActivity findById(Long id) {
+		return volunteerActivityRepository.findById(id)
+			.orElseThrow(() -> new CustomException(NOT_FOUND_VOLUNTEER_ACTIVITY_ERROR));
+	}
+	@Transactional
+	public void deleteActivity(Long id) {
+		volunteerActivityRepository.deleteById(id);
+	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/volunteerActivity/service/VolunteerActivityService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/volunteerActivity/service/VolunteerActivityService.java
@@ -1,5 +1,6 @@
 package com.example.ongi_backend.volunteerActivity.service;
 
+import static com.example.ongi_backend.global.entity.VolunteerStatus.*;
 import static com.example.ongi_backend.global.exception.ErrorCode.*;
 
 import java.util.List;
@@ -10,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.ongi_backend.global.entity.Address;
 import com.example.ongi_backend.global.exception.CustomException;
+import com.example.ongi_backend.user.entity.Elderly;
+import com.example.ongi_backend.volunteerActivity.dto.RequestMatching;
 import com.example.ongi_backend.volunteerActivity.dto.ResponseActivityDetail;
 import com.example.ongi_backend.volunteerActivity.dto.ResponseCompletedActivity;
 import com.example.ongi_backend.volunteerActivity.dto.ResponseMatching;
@@ -95,5 +98,21 @@ public class VolunteerActivityService {
 				.startTime(va.getStartTime())
 				.build();
 		}).collect(Collectors.toList());
+	}
+
+	@Transactional
+	public VolunteerActivity addVolunteerActivity(RequestMatching request, Elderly elderly) {
+		VolunteerActivity volunteerActivity = VolunteerActivity.builder()
+			.elderly(elderly)
+			.volunteer(null)
+			.type(request.getVolunteerType())
+			.addDescription(request.getAddDescription())
+			.startTime(request.getStartTime())
+			.animalType(request.getAnimalType())
+			.status(MATCHING)
+			.address(request.getAddress())
+			.build();
+		VolunteerActivity save = volunteerActivityRepository.save(volunteerActivity);
+		return save;
 	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/weeklyAvailableTime/entity/WeeklyAvailableTime.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/weeklyAvailableTime/entity/WeeklyAvailableTime.java
@@ -1,19 +1,29 @@
 package com.example.ongi_backend.weeklyAvailableTime.entity;
 
+import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
 
 import java.sql.Time;
 import java.time.DayOfWeek;
+import java.time.LocalTime;
 
 import com.example.ongi_backend.user.entity.Volunteer;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
 public class WeeklyAvailableTime {
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
@@ -21,10 +31,8 @@ public class WeeklyAvailableTime {
 	@ManyToOne
 	@JoinColumn(name = "volunteer_id")
 	private Volunteer volunteer;
-
+	@Enumerated(STRING)
 	private DayOfWeek dayOfWeek;
-	private Time availableStartTime;
-
-	//TODO : figma 보니까 끝나는 시간은 따로 명시 안하는거 같아서 삭제해도 될듯
-	private Time availableEndTime;
+	private LocalTime availableStartTime;
+	private LocalTime availableEndTime;
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/weeklyAvailableTime/entity/WeeklyAvailableTime.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/weeklyAvailableTime/entity/WeeklyAvailableTime.java
@@ -4,7 +4,6 @@ import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
-import java.sql.Time;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 
@@ -18,12 +17,16 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
+@ToString
 public class WeeklyAvailableTime {
 	@Id
 	@GeneratedValue(strategy = IDENTITY)

--- a/backend/ongi_backend/src/main/resources/application.yml
+++ b/backend/ongi_backend/src/main/resources/application.yml
@@ -14,7 +14,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
-
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 Authorization:
   header: "Authorization"
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- [ ] #36 


## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- [ ] Redis 설정
- [ ] 노인이 봉사 등록 후 해당 봉사일에 가능한 봉사자가 있으면 매칭, 없으면 `key:unMatching`에 저장
- [ ] 봉사자가 봉사 가능 시간을 수정할 경우 `key:unMatching`에 있는 봉사중 가능한 봉사와 연결
- [ ] VolunteerCategory를 사용한 bitwise를 통해 해당 봉사의 종류가 봉사자의 category와 일치하는지 확인(예시 : 봉사자의 category가 5인 경우 1, 4인 HEALTH, CULTURE 봉사만 매칭)


## 💬 리뷰 요구사항(선택)
> TODO 주석 붙인 부분 수정할 부분이 있는지, 각 파트의 기능만 수행하도록 repository, service, controller를 잘 작성했는지
