### PR TITLE
Feat: 봉사자, 이용자 메인페이지 데이터 조회

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,9 @@
-
-name : Deploy To EC2
+name: Deploy To EC2
 
 on:
   push:
     branches:
-      - feat/75
+      - feat/90
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -33,7 +32,7 @@ jobs:
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
           AWS_SQS_QUEUE_NAME: ${{ secrets.AWS_SQS_QUEUE_NAME }}
           SECRET: ${{ secrets.SECRET }}
-#          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+      #          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
 
       - name: AWS credential setup
         uses: aws-actions/configure-aws-credentials@v4

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/aws/AwsSqsNotificationSender.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/aws/AwsSqsNotificationSender.java
@@ -5,6 +5,7 @@ import static com.example.ongi_backend.global.entity.VolunteerStatus.*;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -129,7 +130,7 @@ public class AwsSqsNotificationSender implements NotificationSender {
 	public void setSchedulingMessageWithTaskScheduler(VolunteerActivity va, Elderly elderly, Volunteer volunteer, String userType) {
 		LocalDateTime time = va.getStartTime();
 		// 봉사까지 1시간도 안남았으면 즉시 전송
-		if(Duration.between(LocalDateTime.now(), time).getSeconds() <= 3600L){
+		if(Duration.between(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime(), time).getSeconds() <= 3600L){
 			scheduleNotification(va.getId(), elderly, volunteer, userType);
 			return ;
 		}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/CurrentMatching.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/CurrentMatching.java
@@ -1,5 +1,7 @@
 package com.example.ongi_backend.global.entity;
 
+import static com.example.ongi_backend.global.entity.VolunteerStatus.*;
+
 import java.time.LocalDateTime;
 
 import com.example.ongi_backend.volunteerActivity.entity.VolunteerActivity;
@@ -14,21 +16,35 @@ import lombok.Data;
 public class CurrentMatching{
 	@Schema(description = "매칭 ID", example = "1")
 	private Long matchingId;
-	@Schema(description = "독거 노인 이름", example = "홍길동")
-	private String elderlyName;
+	@Schema(description = "상대방 이름", example = "홍길동")
+	private String otherName;
 	@Schema(description = "매칭 상태", example = "REVIEWING")
-	private String status;
+	private VolunteerStatus status;
 	private LocalDateTime startTime;
-	public static CurrentMatching of(VolunteerActivity volunteerActivity) {
+	public static CurrentMatching VolunteerOf(VolunteerActivity volunteerActivity) {
 		return CurrentMatching.builder()
 			.matchingId(volunteerActivity.getId())
-			.elderlyName(
+			.otherName(
 				volunteerActivity.getElderly().getName()
 			)
 			.status(
-				volunteerActivity.getStatus().name()
+				volunteerActivity.getStatus()
 			)
 			.startTime(volunteerActivity.getStartTime())
 			.build();
 	}
+	public static CurrentMatching ElderlyOf(VolunteerActivity volunteerActivity) {
+		return CurrentMatching.builder()
+			.matchingId(volunteerActivity.getId())
+			.otherName(
+				volunteerActivity.getVolunteer().getName()
+			)
+			.status(
+				volunteerActivity.getStartTime().isBefore(LocalDateTime.now()) ? STARTED : NOT_STARTED)
+			.startTime(
+				volunteerActivity.getStartTime()
+			)
+			.build();
+	}
+
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/CurrentMatching.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/CurrentMatching.java
@@ -1,0 +1,34 @@
+package com.example.ongi_backend.global.entity;
+
+import java.time.LocalDateTime;
+
+import com.example.ongi_backend.volunteerActivity.entity.VolunteerActivity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@Schema(description = "봉사 진행 여부")
+public class CurrentMatching{
+	@Schema(description = "매칭 ID", example = "1")
+	private Long matchingId;
+	@Schema(description = "독거 노인 이름", example = "홍길동")
+	private String elderlyName;
+	@Schema(description = "매칭 상태", example = "REVIEWING")
+	private String status;
+	private LocalDateTime startTime;
+	public static CurrentMatching of(VolunteerActivity volunteerActivity) {
+		return CurrentMatching.builder()
+			.matchingId(volunteerActivity.getId())
+			.elderlyName(
+				volunteerActivity.getElderly().getName()
+			)
+			.status(
+				volunteerActivity.getStatus().name()
+			)
+			.startTime(volunteerActivity.getStartTime())
+			.build();
+	}
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/CurrentMatching.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/CurrentMatching.java
@@ -3,6 +3,8 @@ package com.example.ongi_backend.global.entity;
 import static com.example.ongi_backend.global.entity.VolunteerStatus.*;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import com.example.ongi_backend.volunteerActivity.entity.VolunteerActivity;
 
@@ -40,7 +42,7 @@ public class CurrentMatching{
 				volunteerActivity.getVolunteer().getName()
 			)
 			.status(
-				volunteerActivity.getStartTime().isBefore(LocalDateTime.now()) ? STARTED : NOT_STARTED)
+				volunteerActivity.getStartTime().isBefore(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime()) ? STARTED : NOT_STARTED)
 			.startTime(
 				volunteerActivity.getStartTime()
 			)

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/CurrentMatching.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/CurrentMatching.java
@@ -42,7 +42,8 @@ public class CurrentMatching{
 				volunteerActivity.getVolunteer().getName()
 			)
 			.status(
-				volunteerActivity.getStartTime().isBefore(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime()) ? STARTED : NOT_STARTED)
+				volunteerActivity.getStatus() == COMPLETED ? COMPLETED : volunteerActivity.getStartTime()
+					.isBefore(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime()) ? STARTED : NOT_STARTED)
 			.startTime(
 				volunteerActivity.getStartTime()
 			)

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/Schedules.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/Schedules.java
@@ -1,0 +1,24 @@
+package com.example.ongi_backend.global.entity;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@Schema(description = "요일별 봉사 가능 시간")
+public class Schedules {
+	@Schema(description = "요일", example = "MONDAY")
+	private DayOfWeek dayOfWeek;
+	private LocalTime time;
+
+	public static Schedules of(DayOfWeek dayOfWeek, LocalTime time) {
+		return Schedules.builder()
+			.dayOfWeek(dayOfWeek)
+			.time(time)
+			.build();
+	}
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/VolunteerInfo.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/VolunteerInfo.java
@@ -1,0 +1,37 @@
+package com.example.ongi_backend.global.entity;
+
+import static com.example.ongi_backend.global.entity.VolunteerStatus.*;
+
+import java.util.List;
+
+import com.example.ongi_backend.user.entity.Volunteer;
+import com.example.ongi_backend.volunteerActivity.entity.VolunteerActivity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@Schema(description = "봉사자 정보")
+public class VolunteerInfo{
+	@Schema(description = "봉사자 이름", example = "홍길동")
+	private String name;
+	@Schema(description = "봉사자 전화번호", example = "010-1234-5678")
+	private String phone;
+	@Schema(description = "봉사자 프로필 이미지", example = "profile/bb0b4359-731e-4cf5-baf0-52251e6b2447")
+	private String profileImage;
+	@Schema(description = "봉사자 봉사 시간", example = "123")
+	private Integer volunteerHours;
+	public static VolunteerInfo of(Volunteer volunteer){
+		List<VolunteerActivity> completeVa = volunteer.getVolunteerActivities().stream().filter(
+			va -> va.getStatus() == COMPLETED
+		).toList();
+		return VolunteerInfo.builder()
+			.name(volunteer.getName())
+			.phone(volunteer.getPhone())
+			.profileImage(volunteer.getProfileImage())
+			.volunteerHours(completeVa.size() * 3)
+			.build();
+	}
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/VolunteerStatus.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/entity/VolunteerStatus.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum VolunteerStatus {
-	COMPLETED("완료된 봉사"), PROGRESS("진행 중인 봉사"), REVIEWING("후기 작성해야 되는 봉사"), MATCHING("매칭중인 봉사"),;
+	COMPLETED("완료된 봉사"), PROGRESS("진행 중인 봉사"), REVIEWING("후기 작성해야 되는 봉사"), MATCHING("매칭중인 봉사"),STARTED("시작된 봉사"), NOT_STARTED("시작 안된 봉사");
 	private final String description;
 
 	VolunteerStatus(String description) {

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,9 @@ package com.example.ongi_backend.global.exception;
 
 import static java.time.LocalDateTime.*;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -20,7 +23,7 @@ public class GlobalExceptionHandler {
 		log.info("exception 발생");
 		HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();
 		ErrorResponse response = ErrorResponse.builder()
-			.timeStamp(now())
+			.timeStamp(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime())
 			.status(e.getErrorCode().getStatus())
 			.error(e.getErrorCode().getCode())
 			.message(e.getMessage())
@@ -33,7 +36,7 @@ public class GlobalExceptionHandler {
 		log.info("exception 발생");
 		HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();
 		ErrorResponse response = ErrorResponse.builder()
-			.timeStamp(now())
+			.timeStamp(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime())
 			.status(400)
 			.error("BAD_REQUEST")
 			.message(e.getBindingResult().getFieldError().getDefaultMessage())

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/exception/JwtExceptionHandler.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/exception/JwtExceptionHandler.java
@@ -2,6 +2,9 @@ package com.example.ongi_backend.global.exception;
 
 import static java.time.LocalDateTime.*;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -40,7 +43,7 @@ public class JwtExceptionHandler {
 	private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
 		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
 		return ErrorResponse.builder()
-			.timeStamp(now())
+			.timeStamp(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime())
 			.status(errorCode.getStatus())
 			.error(errorCode.getCode())
 			.message(errorCode.getMessage())

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/service/NotificationRedisService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/service/NotificationRedisService.java
@@ -2,6 +2,8 @@ package com.example.ongi_backend.global.redis.service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -91,7 +93,7 @@ public class NotificationRedisService {
 			.id(userId)
 			.title(title)
 			.body(body)
-			.createdAt(LocalDateTime.now())
+			.createdAt(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime())
 			.build();
 	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/service/UnMatchingService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/global/redis/service/UnMatchingService.java
@@ -2,6 +2,8 @@ package com.example.ongi_backend.global.redis.service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -31,7 +33,7 @@ public class UnMatchingService {
 			.address(address)
 			.addDescription(addDescription)
 			.ttl(
-				Duration.between(LocalDateTime.now(), startTime).getSeconds()
+				Duration.between(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime(), startTime).getSeconds()
 			)
 			.build());
 	}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/review/controller/ReviewController.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/review/controller/ReviewController.java
@@ -34,10 +34,10 @@ public class ReviewController {
 			));
 	}
 
-	@GetMapping("/{volunteerActivityId}")
+	@GetMapping("/{reviewId}")
 	@Operation(summary = "후기 / 사진추가", description = "리뷰 상세 조회")
-	public ResponseEntity<ResponseDetailReview> getReview(@PathVariable Long volunteerActivityId, Principal principal) {
-		return ResponseEntity.ok(reviewService.findDetailsReview(volunteerActivityId,
+	public ResponseEntity<ResponseDetailReview> getReview(@PathVariable Long reviewId, Principal principal) {
+		return ResponseEntity.ok(reviewService.findDetailsReview(reviewId,
 			principal.getName()
 		));
 	}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/review/repository/ReviewRepository.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/review/repository/ReviewRepository.java
@@ -13,7 +13,7 @@ public interface ReviewRepository extends JpaRepository<VolunteerReview, Long> {
 	@Query("SELECT r FROM VolunteerReview r JOIN FETCH r.volunteerActivity va JOIN FETCH va.elderly e WHERE va.volunteer = :volunteer AND va.status= 'COMPLETED'")
 	public List<VolunteerReview> findByVolunteer(Volunteer volunteer);
 
-	@Query("SELECT r FROM VolunteerReview r JOIN FETCH r.volunteerActivity va JOIN FETCH va.elderly e JOIN FETCH r.images i WHERE va.id = :volunteerActivityId AND va.status = 'COMPLETED'")
-	public Optional<VolunteerReview> findElderlyAndVolunteerActivityAndReviewByVolunteerActivityId(Long volunteerActivityId);
+	@Query("SELECT r FROM VolunteerReview r JOIN FETCH r.volunteerActivity va JOIN FETCH va.elderly e JOIN FETCH r.images i WHERE r.id = :reviewId AND va.status = 'COMPLETED'")
+	public Optional<VolunteerReview> findElderlyAndVolunteerActivityAndReviewByReviewId(Long reviewId);
 
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/review/service/ReviewService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/review/service/ReviewService.java
@@ -60,11 +60,11 @@ public class ReviewService {
 			.toList();
 	}
 
-	public ResponseDetailReview findDetailsReview(Long volunteerActivityId, String username) {
+	public ResponseDetailReview findDetailsReview(Long reviewId, String username) {
 		Volunteer volunteer = (Volunteer)userService.findUserByUserName(username, "volunteer");
 
-		VolunteerReview review = reviewRepository.findElderlyAndVolunteerActivityAndReviewByVolunteerActivityId(
-			volunteerActivityId).orElseThrow(
+		VolunteerReview review = reviewRepository.findElderlyAndVolunteerActivityAndReviewByReviewId(
+			reviewId).orElseThrow(
 			() -> new CustomException(NOT_FOUND_REVIEW_ERROR));
 
 		// 리뷰 작성자가 봉사자와 다르면 리뷰 조회 불가

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/ElderlyController.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/ElderlyController.java
@@ -4,12 +4,14 @@ import java.security.Principal;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.ongi_backend.user.Dto.ResponseElderlyMainPage;
 import com.example.ongi_backend.user.Dto.ResponseMatchedUserInfo;
 import com.example.ongi_backend.user.Service.ElderlyService;
 import com.example.ongi_backend.volunteerActivity.dto.RequestMatching;
@@ -23,6 +25,11 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/elderly")
 public class ElderlyController {
 	private final ElderlyService elderlyService;
+
+	@GetMapping
+	public ResponseEntity<ResponseElderlyMainPage> getElderlyMainPage(Principal principal) {
+		return ResponseEntity.ok(elderlyService.getElderlyMainPage(principal.getName()));
+	}
 
 	@PostMapping("/matching")
 	@Operation(summary = "최종 신청 내역 / 읽기 전용", description = "봉사활동 매칭서 작성, 매칭되었을 때는 봉사자 정보, 없을때는 null 응답")

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/ElderlyController.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/ElderlyController.java
@@ -27,6 +27,7 @@ public class ElderlyController {
 	private final ElderlyService elderlyService;
 
 	@GetMapping
+	@Operation(summary = "봉사탭", description = "봉사탭 메인 페이지")
 	public ResponseEntity<ResponseElderlyMainPage> getElderlyMainPage(Principal principal) {
 		return ResponseEntity.ok(elderlyService.getElderlyMainPage(principal.getName()));
 	}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/VolunteerController.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Controller/VolunteerController.java
@@ -4,12 +4,14 @@ import java.security.Principal;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.ongi_backend.user.Dto.ResponseVolunteerMainPage;
 import com.example.ongi_backend.user.Dto.ScheduleRequest;
 import com.example.ongi_backend.user.Service.VolunteerService;
 
@@ -22,6 +24,12 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/volunteer")
 public class VolunteerController {
 	private final VolunteerService volunteerService;
+
+	@GetMapping
+	@Operation(summary = "main/봉사자", description = "봉사자 메인 페이지 정보 조회")
+	public ResponseEntity<ResponseVolunteerMainPage> getVolunteerMainPage(Principal principal) {
+		return ResponseEntity.ok(volunteerService.getVolunteerMainPage(principal.getName()));
+	}
 
 	@PostMapping("/schedule")
 	@Operation(summary = "나의 봉사 가능 시간 설정", description = "봉사자 봉사 가능 시간, 봉사 타입 설정")

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Dto/ResponseElderlyMainPage.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Dto/ResponseElderlyMainPage.java
@@ -1,0 +1,23 @@
+package com.example.ongi_backend.user.Dto;
+
+import static lombok.AccessLevel.*;
+
+import com.example.ongi_backend.global.entity.CurrentMatching;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+public class ResponseElderlyMainPage {
+	private CurrentMatching currentMatching;
+	public static ResponseElderlyMainPage of(CurrentMatching currentMatching) {
+		return ResponseElderlyMainPage.builder()
+			.currentMatching(currentMatching)
+			.build();
+	}
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Dto/ResponseVolunteerMainPage.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Dto/ResponseVolunteerMainPage.java
@@ -1,0 +1,31 @@
+package com.example.ongi_backend.user.Dto;
+
+import static lombok.AccessLevel.*;
+
+import java.util.List;
+
+import com.example.ongi_backend.global.entity.CurrentMatching;
+import com.example.ongi_backend.global.entity.Schedules;
+import com.example.ongi_backend.global.entity.VolunteerInfo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+public class ResponseVolunteerMainPage {
+	private VolunteerInfo volunteerInfo;
+	private List<Schedules> availableTimes;
+	private CurrentMatching currentMatching;
+	public static ResponseVolunteerMainPage of(VolunteerInfo volunteerInfo, List<Schedules> availableTimes, CurrentMatching currentMatching) {
+		return ResponseVolunteerMainPage.builder()
+			.volunteerInfo(volunteerInfo)
+			.availableTimes(availableTimes)
+			.currentMatching(currentMatching)
+			.build();
+	}
+}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Dto/ScheduleRequest.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Dto/ScheduleRequest.java
@@ -1,10 +1,10 @@
 package com.example.ongi_backend.user.Dto;
 
-import java.time.DayOfWeek;
-import java.time.LocalTime;
 import java.util.List;
 
 import org.hibernate.validator.constraints.Range;
+
+import com.example.ongi_backend.global.entity.Schedules;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -21,10 +21,4 @@ public class ScheduleRequest {
 		+ "\tEDUCATION(8),", minimum = "1", maximum = "15", example = "1")
 	@NotNull
 	private int category;
-	@Data
-	public static class Schedules {
-		@Schema(description = "요일", example = "MONDAY")
-		private DayOfWeek dayOfWeek;
-		private LocalTime time;
-	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
@@ -10,8 +10,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.ongi_backend.global.aws.AwsSqsNotificationSender;
+import com.example.ongi_backend.global.entity.CurrentMatching;
 import com.example.ongi_backend.global.exception.CustomException;
 import com.example.ongi_backend.global.redis.service.UnMatchingService;
+import com.example.ongi_backend.user.Dto.ResponseElderlyMainPage;
 import com.example.ongi_backend.user.Dto.ResponseMatchedUserInfo;
 import com.example.ongi_backend.user.Repository.ElderlyRepository;
 import com.example.ongi_backend.user.entity.Elderly;
@@ -30,6 +32,7 @@ public class ElderlyService {
 	private final VolunteerActivityService volunteerActivityService;
 	private final UnMatchingService unMatchingService;
 	private final VolunteerService volunteerService;
+	private final UserService userService;
 	private final AwsSqsNotificationSender awsSqsNotificationSender;
 
 	@Transactional
@@ -95,5 +98,17 @@ public class ElderlyService {
 	public Elderly findElderlyById(Long id) {
 		return elderlyRepository.findById(id)
 			.orElseThrow(() -> new CustomException(NOT_FOUND_USER_ERROR));
+	}
+
+	public ResponseElderlyMainPage getElderlyMainPage(String name) {
+		Elderly elderly = (Elderly)userService.findUserByUserName(name, "elderly");
+
+		//오늘 날짜
+		VolunteerActivity currentVa = elderly.getVolunteerActivities()
+			.stream()
+			.filter(volunteerActivity ->
+				volunteerActivity.getStartTime().toLocalDate().isEqual(LocalDateTime.now().toLocalDate())
+			).findAny().orElse(null);
+		return ResponseElderlyMainPage.of(currentVa == null ? null : CurrentMatching.ElderlyOf(currentVa));
 	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/ElderlyService.java
@@ -5,6 +5,8 @@ import static com.example.ongi_backend.global.exception.ErrorCode.*;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,7 +39,7 @@ public class ElderlyService {
 
 	@Transactional
 	public ResponseMatchedUserInfo matching(RequestMatching request, String name) {
-		if(Duration.between(LocalDateTime.now(), request.getStartTime()).getSeconds() < 0L) {
+		if(Duration.between(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime(), request.getStartTime()).getSeconds() < 0L) {
 			throw new CustomException(POST_TIME_ERROR);
 		}
 
@@ -107,7 +109,7 @@ public class ElderlyService {
 		VolunteerActivity currentVa = elderly.getVolunteerActivities()
 			.stream()
 			.filter(volunteerActivity ->
-				volunteerActivity.getStartTime().toLocalDate().isEqual(LocalDateTime.now().toLocalDate())
+				volunteerActivity.getStartTime().toLocalDate().isEqual(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime().toLocalDate())
 			).findAny().orElse(null);
 		return ResponseElderlyMainPage.of(currentVa == null ? null : CurrentMatching.ElderlyOf(currentVa));
 	}

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
@@ -8,6 +8,8 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -94,7 +96,7 @@ public class VolunteerService {
 			);
 			findVolunteerActivity.updateVolunteer(null);
 			findVolunteerActivity.updateStatus(MATCHING);
-			if (Duration.between(LocalDateTime.now(), findVolunteerActivity.getStartTime()).getSeconds() < 0L) {
+			if (Duration.between(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime(), findVolunteerActivity.getStartTime()).getSeconds() < 0L) {
 				awsSqsNotificationSender.expireNotification(
 					elderly.getFcmToken(),
 					elderly.getId()
@@ -174,7 +176,7 @@ public class VolunteerService {
 		Volunteer userByUserName = (Volunteer)userService.findUserByUserName(name, "volunteer");
 		// 오늘 날짜
 		VolunteerActivity currentVa = userByUserName.getVolunteerActivities().stream().filter(
-			volunteerActivity -> LocalDate.now().equals(volunteerActivity.getStartTime().toLocalDate())
+			volunteerActivity -> ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate().equals(volunteerActivity.getStartTime().toLocalDate())
 		).findAny().orElse(null);
 		return ResponseVolunteerMainPage.of(VolunteerInfo.of(userByUserName),
 			userByUserName.getWeeklyAvailableTimes().stream().map(

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
@@ -15,11 +15,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.ongi_backend.global.aws.AwsSqsNotificationSender;
+import com.example.ongi_backend.global.entity.CurrentMatching;
+import com.example.ongi_backend.global.entity.VolunteerInfo;
 import com.example.ongi_backend.global.entity.VolunteerType;
 import com.example.ongi_backend.global.exception.CustomException;
 import com.example.ongi_backend.global.redis.service.UnMatchingService;
 import com.example.ongi_backend.user.Dto.ResponseMatchedUserInfo;
-import com.example.ongi_backend.user.Dto.ScheduleRequest;
+import com.example.ongi_backend.user.Dto.ResponseVolunteerMainPage;
+import com.example.ongi_backend.global.entity.Schedules;
 import com.example.ongi_backend.user.Repository.VolunteerRepository;
 import com.example.ongi_backend.user.entity.Elderly;
 import com.example.ongi_backend.user.entity.Volunteer;
@@ -37,13 +40,13 @@ public class VolunteerService {
 	private final VolunteerRepository volunteerRepository;
 	private final VolunteerActivityService volunteerActivityService;
 	private final UnMatchingService unMatchingService;
+	private final UserService userService;
 	private final AwsSqsNotificationSender awsSqsNotificationSender;
 
 	@Transactional
-	public void updateSchedule(List<ScheduleRequest.Schedules> schedules, int category, String username) {
-		Volunteer volunteer = volunteerRepository.findByUsername(username).orElseThrow(
-			() -> new CustomException(NOT_FOUND_USER_ERROR)
-		);
+	public void updateSchedule(List<Schedules> schedules, int category, String username) {
+		Volunteer volunteer = (Volunteer)userService.findUserByUserName(username, "volunteer");
+
 		List<WeeklyAvailableTime> collect = schedules.stream().map(schedule -> WeeklyAvailableTime.builder()
 			.dayOfWeek(schedule.getDayOfWeek())
 			.availableStartTime(schedule.getTime())
@@ -57,7 +60,8 @@ public class VolunteerService {
 
 	@Transactional
 	public void scanUnMatching(List<WeeklyAvailableTime> weeklyAvailableTimes, Volunteer volunteer) {
-		unMatchingService.findAllUnMatching().forEach(unMatching ->
+		unMatchingService.findAllUnMatching().forEach(unMatching -> {
+			if(unMatching == null) return ;
 			weeklyAvailableTimes.forEach(weeklyAvailableTime -> {
 				if (unMatching.getStartTime().getDayOfWeek().equals(weeklyAvailableTime.getDayOfWeek())
 					&& unMatching.getStartTime().toLocalTime().equals(weeklyAvailableTime.getAvailableStartTime())
@@ -68,16 +72,15 @@ public class VolunteerService {
 					.equals(weeklyAvailableTime.getVolunteer().getAddress().getDistrict())) {
 					volunteerActivityService.matchingIfNotAlreadyMatched(unMatching, volunteer);
 				}
-			}));
+			});
+		});
 	}
 
 	@Transactional
 	public void deleteMatching(Long id, String username) {
 		VolunteerActivity findVolunteerActivity = volunteerActivityService.findById(id);
-		// TODO : 현재 로그인된 봉사자의 정보를 가져오는 방법이 따로 있으면 수정
-		Volunteer volunteer = volunteerRepository.findByUsername(username).orElseThrow(
-			() -> new CustomException(NOT_FOUND_USER_ERROR)
-		);
+
+		Volunteer volunteer = (Volunteer)userService.findUserByUserName(username, "volunteer");
 		if (findVolunteerActivity.getVolunteer() == null || !findVolunteerActivity.getVolunteer().equals(volunteer)) {
 			throw new CustomException(ACCESS_DENIED_ERROR);
 		}
@@ -165,5 +168,19 @@ public class VolunteerService {
 				);
 				return null; // 또는 throw new NoMatchingVolunteerException();
 			});
+	}
+
+	public ResponseVolunteerMainPage getVolunteerMainPage(String name) {
+		Volunteer userByUserName = (Volunteer)userService.findUserByUserName(name, "volunteer");
+		// 오늘 날짜
+		VolunteerActivity currentVa = userByUserName.getVolunteerActivities().stream().filter(
+			volunteerActivity -> LocalDate.now().equals(volunteerActivity.getStartTime().toLocalDate())
+		).findAny().orElse(null);
+		return ResponseVolunteerMainPage.of(VolunteerInfo.of(userByUserName),
+			userByUserName.getWeeklyAvailableTimes().stream().map(
+				availTime -> Schedules.of(availTime.getDayOfWeek(), availTime.getAvailableStartTime())
+			).collect(Collectors.toList()), currentVa == null ? null : CurrentMatching.of(
+				currentVa
+			));
 	}
 }

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
@@ -179,7 +179,7 @@ public class VolunteerService {
 		return ResponseVolunteerMainPage.of(VolunteerInfo.of(userByUserName),
 			userByUserName.getWeeklyAvailableTimes().stream().map(
 				availTime -> Schedules.of(availTime.getDayOfWeek(), availTime.getAvailableStartTime())
-			).collect(Collectors.toList()), currentVa == null ? null : CurrentMatching.of(
+			).collect(Collectors.toList()), currentVa == null ? null : CurrentMatching.VolunteerOf(
 				currentVa
 			));
 	}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- [ ] #90 


## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- [ ] 봉사자, 이용자 메인 페이지 데이터 조회
- [ ] 클라우드 환경에서 시간 정보 통일을 위해 ZoneTime 적용
- [ ] 이용자 메인화면을 위한 봉사 상태 추가(STARTED, NOT_STARTED)
- [ ] Redis 매칭 안된 봉사 조회 시 null 이면 Exception 발생을 막기 위해 그냥 return


## 💬 리뷰 요구사항(선택)
> ex) 메서드 이름 적절한가요?
