### PR TITLE
Feat: 카카오 로그인 실패 핸들러 구현 

### DIFF
--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/Security/SecurityConfig.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/Security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.ongi_backend.Security;
 import com.example.ongi_backend.Security.Jwt.CustomAuthenticationEntryPoint;
 import com.example.ongi_backend.Security.Jwt.JwtFilter;
 import com.example.ongi_backend.Security.Jwt.JwtProvider;
+import com.example.ongi_backend.Security.oauth.OAuth2FailureHandler;
 import com.example.ongi_backend.Security.oauth.OAuth2SuccessHandler;
 import com.example.ongi_backend.Security.oauth.OAuth2UserService;
 import com.example.ongi_backend.user.Service.UserService;
@@ -31,6 +32,7 @@ public class SecurityConfig {
     private final OAuth2UserService oAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final ObjectProvider<UserService> userServiceProvider;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -71,7 +73,8 @@ public class SecurityConfig {
                 .oauth2Login((auth) -> auth
                         .loginPage("/login/kakao")
                         .userInfoEndpoint(c -> c.userService(oAuth2UserService))
-                        .successHandler(oAuth2SuccessHandler))
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailureHandler))
 
                 // jwt 사용으로 인해 세션 방식을 사용하지 않음
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/Security/oauth/OAuth2FailureHandler.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/Security/oauth/OAuth2FailureHandler.java
@@ -1,0 +1,24 @@
+package com.example.ongi_backend.Security.oauth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        exception.printStackTrace();
+
+        String redirectUrl = UriComponentsBuilder.fromUriString("https://capstone-2025-29-vercel.vercel.app/login")
+                .build().toUriString();
+        response.sendRedirect(redirectUrl);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- [ ] #113


## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- [ ] 카카오 로그인 실패 시 로그인 창으로 리다이렉트 되도록 구현


## 💬 리뷰 요구사항(선택)
> ex) 메서드 이름 적절한가요?
