### PR TITLE
Fix : 봉사자 취소 로직 수정

### DIFF
--- a/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
+++ b/backend/ongi_backend/src/main/java/com/example/ongi_backend/user/Service/VolunteerService.java
@@ -139,7 +139,7 @@ public class VolunteerService {
 					findVolunteerActivity.updateStatus(PROGRESS);
 					findVolunteerActivity.updateVolunteer(v);
 
-					return null;
+					return true;
 				})
 				.orElseGet(() -> {
 					// 매칭 실패 처리


### PR DESCRIPTION
- return null을 통해 orElseGet으로 넘어가는 문제 해결

## #️⃣ 연관된 이슈
- [ ] #115 


## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- [ ] `return null` 을 통한 `orElseGet()` 진입으로 인해 봉사자가 존재함에도 없는 것을 처리하는 문제 해결


## 💬 리뷰 요구사항(선택)
> ex) 메서드 이름 적절한가요?
